### PR TITLE
fix(services): providers field in @Component

### DIFF
--- a/docs/guide/services/one-service.md
+++ b/docs/guide/services/one-service.md
@@ -48,7 +48,6 @@ import { Phone } from './phone'
       </table>
     </div>
   `,
-  providers: [DataService, LogService],
 })
 export class DataComponent implements OnInit {
   items: Phone[] = []


### PR DESCRIPTION
I don't know, mb in later angular versions **providers** is necessary, but now as I know it's make no sense. You need just declare your service in declarations (app module), and that's all.